### PR TITLE
Add sudo=yes for unpacking to fix failing ansible build

### DIFF
--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -12,6 +12,7 @@
   tags: iojs
 
 - name: Unpack
+  sudo: yes
   unarchive:
     src=/tmp/{{ iojs_filename }}.tar.xz
     dest=/usr/local/lib


### PR DESCRIPTION
Adding sudo=yes to source.yml fixes the issue of failing io.js ansible-runs on an ubuntu vagrant box
